### PR TITLE
Improve the composer metadata

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,11 +1,11 @@
 {
     "name": "symfony/orm-pack",
-    "type": "library",
+    "type": "metapackage",
     "license": "MIT",
     "description": "A pack for the Doctrine ORM",
     "require": {
         "php": "^7.0",
-        "doctrine/orm": "~2.4,>=2.4.5",
-        "doctrine/doctrine-bundle": "~1.2"
+        "doctrine/orm": "^2.4.5",
+        "doctrine/doctrine-bundle": "^1.6"
     }
 }


### PR DESCRIPTION
- use a metapackage to tell composer that there is no code to download
- enforce using a maintained version of DoctrineBundle rather than a very old version