### PR TITLE
Fix dependencies for doctrine-bundle to avoid crash with SF 4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "description": "A pack for the Doctrine ORM",
     "require": {
         "php": "^7.0",
-        "doctrine/orm": "^2.5.11",
-        "doctrine/doctrine-bundle": "^1.6.10"
+        "doctrine/orm": "^2.5.12",
+        "doctrine/doctrine-bundle": ">=1.6.13 <1.7"
     }
 }


### PR DESCRIPTION
Update dependencies to fix issues while requiring this recipe for a 4.0-alpha symfony project.
This change ensure to have a non crashing recipe while waiting a new release on the 1.7 branch of the doctrine bundle.