### PR TITLE
Proposing the addition of DoctrineMigrationsBundle to the pack

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
     "require": {
         "php": "^7.0",
         "doctrine/orm": "^2.5.11",
-        "doctrine/doctrine-bundle": "^1.6.10"
+        "doctrine/doctrine-bundle": "^1.6.10",
+        "doctrine/doctrine-migrations-bundle": "^1.2"
     }
 }


### PR DESCRIPTION
Hi guys!

This makes the pack a bit more opinionated, but I think it make sense:

A) DoctrineMigrationsBundle is the "official" migrations library for Doctrine
B) Most/All frameworks package migrations functionality with their ORM.

Thanks!