### PR TITLE
Bump doctrine/orm: ^2.5.11 -> ^2.6.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "description": "A pack for the Doctrine ORM",
     "require": {
         "php": "^7.0",
-        "doctrine/orm": "^2.5.11",
+        "doctrine/orm": "^2.6.3",
         "doctrine/doctrine-bundle": "^1.6.10",
         "doctrine/doctrine-migrations-bundle": "^1.3"
     }


### PR DESCRIPTION
Current version of Doctrine in `symfony/orm-pack` is meeting compatibility issues with PHP 7.3.

See https://github.com/doctrine/doctrine2/issues/7402 from Doctrine repository.

So we need `doctrine/orm:2.6.3`. Otherwise, Doctrine will keep raising this:
```bash
$ php7.3 bin/console doctrine:fixtures:load

In UnitOfWork.php line 2718:
Warning: "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"?
```

This would also resolve https://github.com/symfony/orm-pack/issues/11.