### PR TITLE
Bump DoctrineMigrationsBundle version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,6 @@
         "php": "^7.0",
         "doctrine/orm": "^2.5.11",
         "doctrine/doctrine-bundle": "^1.6.10",
-        "doctrine/doctrine-migrations-bundle": "^1.3"
+        "doctrine/doctrine-migrations-bundle": "^2.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,6 @@
         "php": "^7.0",
         "doctrine/orm": "^2.5.11",
         "doctrine/doctrine-bundle": "^1.6.10",
-        "doctrine/doctrine-migrations-bundle": "^2.0"
+        "doctrine/doctrine-migrations-bundle": "^1.3|^2.0"
     }
 }


### PR DESCRIPTION
DoctrineMigrationsBundle v2.0.0 has been released: https://github.com/doctrine/DoctrineMigrationsBundle/tree/v2.0.0