### PR TITLE
Drop version constraint to allow future package releases (or abandon package)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,9 +4,8 @@
     "license": "MIT",
     "description": "A pack for the Doctrine ORM",
     "require": {
-        "php": "^7.0",
-        "doctrine/orm": "^2.5.11",
-        "doctrine/doctrine-bundle": "^1.6.10|^2.0",
-        "doctrine/doctrine-migrations-bundle": "^1.3|^2.0"
+        "doctrine/orm": "*",
+        "doctrine/doctrine-bundle": "*",
+        "doctrine/doctrine-migrations-bundle": "*"
     }
 }


### PR DESCRIPTION
I can immagine that this is going to be a bit controversial, but I'm not sure if this package was a good idea.

When users use `symfony/orm-pack` they get some doctrine packages as  "doctrine/doctrine-migrations-bundle", versions  ^1. or ^2.0, 

When doctrine/doctrine-migrations-bundle 3.0 will be released (or orm 3.0 or dbal 2.0), the only way to allow the upgrade it is to allow it in this package, as example defining `doctrine/doctrine-migrations-bundle: ^1.3|^2.0|3.0` (an example was https://github.com/symfony/orm-pack/commit/c8b2fd476a8c9686d752f275d5b607b8101d079d)

But since that was a minor/bigfix release, any user that had installed `symfony/orm-pack` got automatically installed (as bugfix) `doctrine/doctrine-migrations-bundle 2.0` that was a major release with BC breaks. This already was reported in https://github.com/symfony/orm-pack/issues/15, I'm not aware of packs being unpacked by composer... is that true?

My proposal to remove the version constraint has the same disadvantages, but does not oblige the doctrine team to keep updated this repo each time there is a major release on doctrine.

Another solution is that each time a major release is added in the constraints, this package should release a major release, in this way we avoid delivering unexpected major releases. Similar as https://github.com/symfony/orm-pack/issues/18

A third solution (that does not exclude the previous one) is to deprecate this package and let users install what do they need.

