### PR TITLE
Set fixed version 2 of Doctrine

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,8 @@
     "license": "MIT",
     "description": "A pack for the Doctrine ORM",
     "require": {
-        "doctrine/orm": "*",
-        "doctrine/doctrine-bundle": "*",
-        "doctrine/doctrine-migrations-bundle": "*"
+        "doctrine/orm": "2.*",
+        "doctrine/doctrine-bundle": "2.*",
+        "doctrine/doctrine-migrations-bundle": "2.*"
     }
 }


### PR DESCRIPTION
Version 3 of Doctrine Migrations has brand new configuration without backward capability.
Also, first migration throws and error: `[ERROR] The version "latest" couldn't be reached, you are at version "0"` which broke Symfony application inside docker container.

Let's add this PR as version 1.0.9 and create a new one 2.0.0 with doctrine 3.*