### PR TITLE
Replace ocramius/package-versions, it breaks Composer 1+2 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,7 @@
     "license": "MIT",
     "description": "A pack for the Doctrine ORM",
     "require": {
+        "composer/package-versions-deprecated: "*",
         "doctrine/orm": "*",
         "doctrine/doctrine-bundle": "*",
         "doctrine/doctrine-migrations-bundle": "*"


### PR DESCRIPTION
Newest versions of `doctrine/*` already list this package, but none of them have been tagged (and this is still needed for previous versions.)