### PR TITLE
Stick to v2 of doctrine/*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,9 +4,9 @@
     "license": "MIT",
     "description": "A pack for the Doctrine ORM",
     "require": {
-        "composer/package-versions-deprecated: "*",
-        "doctrine/orm": "*",
-        "doctrine/doctrine-bundle": "*",
-        "doctrine/doctrine-migrations-bundle": "*"
+        "composer/package-versions-deprecated": "*",
+        "doctrine/orm": "^2",
+        "doctrine/doctrine-bundle": "^2",
+        "doctrine/doctrine-migrations-bundle": "^2"
     }
 }


### PR DESCRIPTION
Fix #18
Similar to #25
I failed at other approaches I was advocating :)
The World is not ready for migration v3, neither for dbal v3 not orm v3 when they'll be released.

To be tagged as v1.1.0

If you need v3, unpack. See #29.