### PR TITLE
Remove dependency on composer/package-versions-deprecated

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,6 @@
     "license": "MIT",
     "description": "A pack for the Doctrine ORM",
     "require": {
-        "composer/package-versions-deprecated": "*",
         "doctrine/orm": "*",
         "doctrine/doctrine-bundle": "*",
         "doctrine/doctrine-migrations-bundle": "*",


### PR DESCRIPTION
The justification is the same than in https://github.com/symfony/symfony/pull/44767

Contributes to https://github.com/symfony/symfony/issues/44726