### PR TITLE
Remove proxy-manager-bridge

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,9 @@
     "require": {
         "doctrine/orm": "*",
         "doctrine/doctrine-bundle": "*",
-        "doctrine/doctrine-migrations-bundle": "*",
-        "symfony/proxy-manager-bridge": "*"
+        "doctrine/doctrine-migrations-bundle": "*"
+    },
+    "conflict": {
+        "symfony/dependency-injection": "<6.2"
     }
 }


### PR DESCRIPTION
Not needed in 6.2 after https://github.com/symfony/symfony/pull/46752