### PR TITLE
Remove conflict with symfony/dependency-injection < 6.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,8 +7,5 @@
         "doctrine/orm": "*",
         "doctrine/doctrine-bundle": "*",
         "doctrine/doctrine-migrations-bundle": "*"
-    },
-    "conflict": {
-        "symfony/dependency-injection": "<6.2"
     }
 }


### PR DESCRIPTION
This works around #37 

Note that after https://github.com/composer/composer/pull/11160, Composer 2.5 would be able to take the conflict into account and thus not fall into #37, but we're not yet there.