### PR TITLE
Forbid DBAL v4 for now

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,7 @@
     "license": "MIT",
     "description": "A pack for the Doctrine ORM",
     "require": {
+        "doctrine/dbal": "^3",
         "doctrine/orm": "*",
         "doctrine/doctrine-bundle": "*",
         "doctrine/doctrine-migrations-bundle": "*"


### PR DESCRIPTION
Symfony doesn't support DBAL 4 yet as it drops support for events that we are using in Messenger for instance (https://github.com/doctrine/dbal/blob/1a307d92f8531b0897176e95040051c7414d80a5/UPGRADE.md?plain=1#L1065).

