### PR TITLE
allow any doctrine/dbal, including ^4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,6 @@
     "license": "MIT",
     "description": "A pack for the Doctrine ORM",
     "require": {
-        "doctrine/dbal": "*",
         "doctrine/orm": "*",
         "doctrine/doctrine-bundle": "*",
         "doctrine/doctrine-migrations-bundle": "*"

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "license": "MIT",
     "description": "A pack for the Doctrine ORM",
     "require": {
-        "doctrine/dbal": "^3",
+        "doctrine/dbal": "*",
         "doctrine/orm": "*",
         "doctrine/doctrine-bundle": "*",
         "doctrine/doctrine-migrations-bundle": "*"


### PR DESCRIPTION
Changed doctrine/dbal version constraint to allow any version.

Fixes
```
symfony new --webapp test-webapp && cd test-webapp && composer outdated
* Creating a new Symfony project with Composer
* Setting up the project under Git version control
  (running git init /home/tac/trash/test-webapp)

                                                                                                                        
 [OK] Your project is now ready in /home/tac/trash/test-webapp                                                          
                                                                                                                        

Color legend:
- patch or minor release available - update recommended
- major release available - update possible

Direct dependencies required in composer.json:
doctrine/dbal            3.10.3 4.3.4 Powerful PHP database abstraction layer (DBAL) with many features for database schema introspection and management.
doctrine/doctrine-bundle 2.18.1 3.0.0 Symfony DoctrineBundle

Transitive dependencies not required in composer.json:
Everything up to date
```