### PR TITLE
Revert "feature #46 allow any doctrine/dbal, including ^4"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,7 @@
     "license": "MIT",
     "description": "A pack for the Doctrine ORM",
     "require": {
+        "doctrine/dbal": "^3",
         "doctrine/orm": "*",
         "doctrine/doctrine-bundle": "*",
         "doctrine/doctrine-migrations-bundle": "*"


### PR DESCRIPTION
This reverts commit ca19fea56d4987a1cd87dfd037c2486b676310d7, reversing changes made to 9d8729016b3a8b0db854c028d15c2dcf4d19b1b4.

The reason is https://github.com/symfony/symfony/issues/54039, and more specifically https://github.com/symfony/symfony/issues/62481
DBAL v4 doesn't allow the level of DX we have with v3.

See also https://github.com/doctrine/orm/issues/10208